### PR TITLE
Modification to build libGenISAIntrinsics.a with LLVM 17

### DIFF
--- a/IGC/Compiler/CodeGenPublic.h
+++ b/IGC/Compiler/CodeGenPublic.h
@@ -1139,7 +1139,7 @@ namespace IGC
         uint64_t GetSIMDInfo() { return m_SIMDInfo; }
 
         virtual llvm::Optional<SIMDMode> knownSIMDSize() const {
-            return llvm::None;
+            return std::nullopt;
         }
 
         // This can be paired with `EncodeAS4GFXResource()` to get a unique

--- a/IGC/GenISAIntrinsics/GenIntrinsicFunctions.cpp
+++ b/IGC/GenISAIntrinsics/GenIntrinsicFunctions.cpp
@@ -246,7 +246,7 @@ private:
         llvm::AttributeList AS[1];
         AS[0] = llvm::AttributeList::get(ctx, llvm::AttributeList::FunctionIndex, attributeKinds);
         unsigned NumAttrs = attributeKinds.size() > 0 ? 1 : 0;
-        return llvm::AttributeList::get(ctx, makeArrayRef(AS, NumAttrs));
+        return llvm::AttributeList::get(ctx, llvm::ArrayRef<llvm::AttributeList>(AS, NumAttrs));
     }
 };
 

--- a/IGC/GenISAIntrinsics/GenIntrinsicFunctions.cpp
+++ b/IGC/GenISAIntrinsics/GenIntrinsicFunctions.cpp
@@ -155,6 +155,31 @@ private:
         // is global and hence this approach suffices.
         pFunc->setAttributes(attribs);
 
+        // Set MemoryEffects
+        constexpr auto& memoryEffectKinds = IntrinsicDefinitionT::scMemoryEffectKinds;
+        for (const auto& el : memoryEffectKinds) {
+            switch (el) {
+                case Undef:
+                    break;
+                case ReadNone:
+                    pFunc->setDoesNotAccessMemory();
+                    break;
+                case ReadOnly:
+                    pFunc->setOnlyReadsMemory();
+                    break;
+                case WriteOnly:
+                    pFunc->setOnlyWritesMemory();
+                    break;
+                case ArgMemOnly:
+                    pFunc->setOnlyAccessesArgMemory();
+                    break;
+                case InaccessibleMemOnly:
+                    pFunc->setOnlyAccessesInaccessibleMemory();
+                    break;
+                default:
+                    IGC_ASSERT_MESSAGE(false, "Unknown memory side effect kind!");
+            }
+        }
         return pFunc;
     }
 

--- a/IGC/GenISAIntrinsics/GenIntrinsics.h
+++ b/IGC/GenISAIntrinsics/GenIntrinsics.h
@@ -25,7 +25,7 @@ namespace GenISAIntrinsic
 
 /// Intrinsic::getName(ID) - Return the LLVM name for an intrinsic, such as
 /// "llvm.ppc.altivec.lvx".
-std::string getName(ID id, ArrayRef<Type*> Tys = None);
+std::string getName(ID id, ArrayRef<Type*> Tys = std::nullopt);
 
 
 struct IntrinsicComments
@@ -53,7 +53,7 @@ IntrinsicComments getIntrinsicComments(ID id);
 ///    Type Ts[2]{int2, int2}: to resolve to the first instance.
 ///    Type Ts[2]{int4, int4}: to resolve to the second.
 #if defined(ANDROID) || defined(__linux__)
-__attribute__ ((visibility ("default"))) Function *getDeclaration(Module *M, ID id, ArrayRef<Type*> OverloadedTys = None);
+__attribute__ ((visibility ("default"))) Function *getDeclaration(Module *M, ID id, ArrayRef<Type*> OverloadedTys = std::nullopt);
 #else
 Function *getDeclaration(Module *M, ID id, ArrayRef<Type*> OverloadedTys = None);
 #endif

--- a/IGC/GenISAIntrinsics/generator/Intrinsic_definition_objects.py
+++ b/IGC/GenISAIntrinsics/generator/Intrinsic_definition_objects.py
@@ -66,30 +66,22 @@ class AttributeID(Enum):
         else:
             raise ValueError("{value} is not present in {cls.__name__}")
 
-class ParameterAttributeID(Enum):
-    ReadNone = 0,
-    ReadOnly = 1,
-    WriteOnly = 2,
-
-    def __str__(self):
-        return self.name
-
-    @classmethod
-    def from_str(cls, value : str):
-        for key, val in cls.__members__.items():
-            if key == value:
-                return val
-        else:
-            raise ValueError("{value} is not present in {cls.__name__}")
-
 class MemoryEffectID(Enum):
-    ArgMemOnly = 0,
-    InaccessibleMemOnly = 1
+    Undef = 0,
+    ReadNone = 1,
+    ReadOnly = 2,
+    WriteOnly = 3
+    ArgMemOnly = 4,
+    InaccessibleMemOnly = 5
 
     def __str__(self):
         effect_to_string = {
-            MemoryEffectID.ArgMemOnly: "ArgMem",
-            MemoryEffectID.InaccessibleMemOnly: "InaccessibleMem"
+            MemoryEffectID.Undef: "Undef",
+            MemoryEffectID.ReadNone: "ReadNone",
+            MemoryEffectID.ReadOnly: "ReadOnly",
+            MemoryEffectID.WriteOnly: "WriteOnly",
+            MemoryEffectID.ArgMemOnly: "ArgMemOnly",
+            MemoryEffectID.InaccessibleMemOnly: "InaccessibleMemOnly"
         }
         return effect_to_string[self]
 
@@ -209,13 +201,12 @@ class ArgumentTypeDefinition:
 
 class IntrinsicDefinition:
     def __init__(self, name : str, comment : str, return_type : ArgumentTypeDefinition,
-                 argument_types : List[ArgumentTypeDefinition], attributes : Set[AttributeID], parameter_attributes : Set[ParameterAttributeID], memory_effects : Set[MemoryEffectID]):
+                 argument_types : List[ArgumentTypeDefinition], attributes : Set[AttributeID], memory_effects : Set[MemoryEffectID]):
         self.name = name
         self.comment = comment
         self.return_type = return_type
         self.argument_types = argument_types
         self.attributes = sorted(list(attributes), key=lambda x: x.__str__())
-        self.parameter_attributes = sorted(list(parameter_attributes), key=lambda x: x.__str__())
         self.memory_effects = sorted(list(memory_effects), key=lambda x: x.__str__())
 
     def to_dict(self):
@@ -225,7 +216,6 @@ class IntrinsicDefinition:
             "return_type": self.return_type.to_dict(),
             "argument_types":[ el.to_dict() for el in self.argument_types],
             "attributes": [str(el) for el in self.attributes],
-            "parameter_attributes": [str(el) for el in self.parameter_attributes],
             "memory_effects": [str(el) for el in self.memory_effects]
         }
         return res
@@ -237,7 +227,6 @@ class IntrinsicDefinition:
         for arg in json_dct['argument_types']:
             argument_types.append(ArgumentTypeDefinition.from_dict(arg))
         attributes = set(AttributeID.from_str(el) for el in json_dct['attributes'])
-        parameter_attributes = set(ParameterAttributeID.from_str(el) for el in json_dct['parameter_attributes'])
         memory_effects = set(MemoryEffectID.from_str(el) for el in json_dct['memory_effects'])
         return IntrinsicDefinition(json_dct['name'], json_dct['comment'], return_type,
-                                   argument_types, attributes, parameter_attributes, memory_effects)
+                                   argument_types, attributes, memory_effects)

--- a/IGC/GenISAIntrinsics/generator/Intrinsic_definition_translation.py
+++ b/IGC/GenISAIntrinsics/generator/Intrinsic_definition_translation.py
@@ -148,36 +148,17 @@ def translate_attribute_list_func_attribute(attribute):
     }
     return attribute_map[attribute]
 
-def translate_attribute_list_parameter_attribute(attribute):
-    if ',' in attribute:
-        attributes = attribute.split(",")
-        return set(ID for attribute in attributes for ID in translate_attribute_list_func_attribute(attribute))
-    attribute_map = {
-        "None": set([ ]),
-        "NoMem": set([ ParameterAttributeID.ReadNone ]),
-        "ReadMem": set([ ParameterAttributeID.ReadOnly]),
-        "ReadArgMem": set([ ParameterAttributeID.ReadOnly ]),
-        "WriteArgMem": set([ ParameterAttributeID.WriteOnly ]),
-        "WriteMem": set([ ParameterAttributeID.WriteOnly ]),
-        "ReadWriteArgMem": set([ ]),
-        "NoReturn": set([ ]),
-        "NoDuplicate": set([ ]),
-        "Convergent": set([ ]),
-        "InaccessibleMemOnly": set([ ])
-    }
-    return attribute_map[attribute]
-
 def translate_attribute_list_memory_effect(attribute):
     if ',' in attribute:
         attributes = attribute.split(",")
         return set(ID for attribute in attributes for ID in translate_attribute_list_memory_effect(attribute))
     attribute_map = {
         "None": set([ ]),
-        "NoMem": set([ ]),
-        "ReadMem": set([ ]),
-        "ReadArgMem": set([ MemoryEffectID.ArgMemOnly ]),
-        "WriteArgMem": set([ MemoryEffectID.ArgMemOnly ]),
-        "WriteMem": set([ ]),
+        "NoMem": set([ MemoryEffectID.ReadNone ]),
+        "ReadMem": set([ MemoryEffectID.ReadOnly ]),
+        "ReadArgMem": set([ MemoryEffectID.ReadOnly, MemoryEffectID.ArgMemOnly ]),
+        "WriteArgMem": set([ MemoryEffectID.WriteOnly, MemoryEffectID.ArgMemOnly ]),
+        "WriteMem": set([ MemoryEffectID.WriteOnly ]),
         "ReadWriteArgMem": set([ MemoryEffectID.ArgMemOnly ]),
         "NoReturn": set([ ]),
         "NoDuplicate": set([ ]),
@@ -211,9 +192,10 @@ def generate_type_definitions_from_modules(inputs):
         for type_str in argument_type_strs:
             argument_types.append(ArgumentTypeDefinition(translate_type_definition(type_str[0]), type_str[1]))
         attributes = translate_attribute_list_func_attribute(func_type_def[2])
-        parameter_attributes = translate_attribute_list_parameter_attribute(func_type_def[2])
         memory_effects = translate_attribute_list_memory_effect(func_type_def[2])
-        intrinsic_definitions.append(IntrinsicDefinition(name, comment, return_type, argument_types, attributes, parameter_attributes, memory_effects))
+        if len(memory_effects) == 0:
+            memory_effects.add(MemoryEffectID.Undef)
+        intrinsic_definitions.append(IntrinsicDefinition(name, comment, return_type, argument_types, attributes, memory_effects))
     return intrinsic_definitions
 
 if __name__ == '__main__':

--- a/IGC/GenISAIntrinsics/generator/Intrinsic_generator.py
+++ b/IGC/GenISAIntrinsics/generator/Intrinsic_generator.py
@@ -150,15 +150,8 @@ class IntrinsicFormatter:
         return output
 
     @staticmethod
-    def get_parameter_attribute_entry(attribute, is_last):
-        output = 'llvm::Attribute::{}'.format(attribute)
-        if not is_last:
-            output = "{},".format(output)
-        return output
-
-    @staticmethod
     def get_memory_effect_entry(effect, is_last):
-        output = 'llvm::MemoryEffects::Location::{}'.format(effect)
+        output = 'MemorySideEffects::{}'.format(effect)
         if not is_last:
             output = "{},".format(output)
         return output   

--- a/IGC/GenISAIntrinsics/generator/templates/GenIntrinsicDefinition.h.mako
+++ b/IGC/GenISAIntrinsics/generator/templates/GenIntrinsicDefinition.h.mako
@@ -24,6 +24,16 @@ namespace IGC
 
 static constexpr std::string_view scIntrinsicPrefix = "${IntrinsicFormatter.get_prefix()}";
 
+enum MemorySideEffects : uint8_t
+{
+    Undef = 0,
+    ReadNone = 1,
+    ReadOnly = 2,
+    WriteOnly = 3,
+    ArgMemOnly = 4,
+    InaccessibleMemOnly = 5
+};
+
 template<llvm::GenISAIntrinsic::ID id>
 struct IntrinsicDefinition;
 
@@ -66,22 +76,14 @@ public:
         % endfor
     };
     % endif
+    % if hasattr(el, 'memory_effects') and el.memory_effects and len(el.memory_effects) > 0:
 
-    static constexpr std::vector scParameterAttributeKinds = {
-        % if hasattr(el, 'parameter_attributes') and el.parameter_attributes and len(el.parameter_attributes) >0:
-            % for attr in el.parameter_attributes:
-            ${IntrinsicFormatter.get_parameter_attribute_entry(attr, loop.last)}
-            % endfor
-        % endif
+    static constexpr std::array scMemoryEffectKinds = {
+        % for attr in el.memory_effects:
+        ${IntrinsicFormatter.get_memory_effect_entry(attr, loop.last)}
+        % endfor
     };
-
-    static constexpr std::vector scMemoryEffectKinds = {
-        % if hasattr(el, 'memory_effects') and el.memory_effects and len(el.memory_effects) >0:
-            % for attr in el.memory_effects:
-            ${IntrinsicFormatter.get_memory_effect_entry(attr, loop.last)}
-            % endfor
-        % endif
-    };
+    % endif
 };
 
 % endfor

--- a/IGC/WrapperLLVM/include/llvmWrapper/IR/DerivedTypes.h
+++ b/IGC/WrapperLLVM/include/llvmWrapper/IR/DerivedTypes.h
@@ -33,7 +33,7 @@ namespace IGCLLVM
 #if LLVM_VERSION_MAJOR <= 10
         return llvm::cast<llvm::VectorType>(pType)->getBitWidth();
 #else
-        return (uint32_t)pType->getPrimitiveSizeInBits().getFixedSize();
+        return (uint32_t)pType->getPrimitiveSizeInBits().getFixedValue();
 #endif
     }
 

--- a/IGC/WrapperLLVM/include/llvmWrapper/IR/IRBuilder.h
+++ b/IGC/WrapperLLVM/include/llvmWrapper/IR/IRBuilder.h
@@ -31,28 +31,28 @@ namespace IGCLLVM
     public:
         IRBuilder(llvm::LLVMContext &C, const T &F, InserterTyDef() I = InserterTyDef()(),
             llvm::MDNode *FPMathTag = nullptr,
-            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = llvm::None)
+            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = std::nullopt)
             : llvm::IRBuilder<T, InserterTyDef()>(C, F, I, FPMathTag, OpBundles) {}
 
         explicit IRBuilder(llvm::LLVMContext &C, llvm::MDNode *FPMathTag = nullptr,
-            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = llvm::None)
+            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = std::nullopt)
             : llvm::IRBuilder<T, InserterTyDef()>(C, FPMathTag, OpBundles) {}
 
         explicit IRBuilder(llvm::BasicBlock *TheBB, llvm::MDNode *FPMathTag = nullptr)
             : llvm::IRBuilder<T, InserterTyDef()>(TheBB, FPMathTag) {}
 
         explicit IRBuilder(llvm::Instruction *IP, llvm::MDNode *FPMathTag = nullptr,
-            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = llvm::None)
+            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = std::nullopt)
             : llvm::IRBuilder<T, InserterTyDef()>(IP, FPMathTag, OpBundles) {}
 
         IRBuilder(llvm::BasicBlock *TheBB, llvm::BasicBlock::iterator IP, const T &F,
             llvm::MDNode *FPMathTag = nullptr,
-            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = llvm::None)
+            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = std::nullopt)
             : llvm::IRBuilder<T, InserterTyDef()>(TheBB, IP, F, FPMathTag, OpBundles) {}
 
         IRBuilder(llvm::BasicBlock *TheBB, llvm::BasicBlock::iterator IP,
             llvm::MDNode *FPMathTag = nullptr,
-            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = llvm::None)
+            llvm::ArrayRef<llvm::OperandBundleDef> OpBundles = std::nullopt)
             : llvm::IRBuilder<T, InserterTyDef()>(TheBB, IP, FPMathTag, OpBundles) {}
 
         const T& getFolder() {
@@ -166,7 +166,7 @@ namespace IGCLLVM
 #endif
 
 #if LLVM_VERSION_MAJOR >= 11
-      inline llvm::CallInst* CreateCall(llvm::Value* Callee, llvm::ArrayRef<llvm::Value*> Args = llvm::None,
+      inline llvm::CallInst* CreateCall(llvm::Value* Callee, llvm::ArrayRef<llvm::Value*> Args = std::nullopt,
                                            const llvm::Twine& Name = "", llvm::MDNode* FPMathTag = nullptr) {
             return llvm::IRBuilder<T, InserterTyDef()>::CreateCall(
                                                            llvm::cast<llvm::FunctionType>(IGCLLVM::getNonOpaquePtrEltTy(Callee->getType())), Callee,
@@ -186,7 +186,7 @@ namespace IGCLLVM
 
         inline llvm::CallInst *
         CreateCall(llvm::FunctionType *FTy, llvm::Value *Callee,
-                   llvm::ArrayRef<llvm::Value *> Args = llvm::None,
+                   llvm::ArrayRef<llvm::Value *> Args = std::nullopt,
                    const llvm::Twine &Name = "",
                    llvm::MDNode *FPMathTag = nullptr) {
           return llvm::IRBuilder<T, InserterTyDef()>::CreateCall(FTy, Callee, Args,


### PR DESCRIPTION
The main change is with LLVM Function Attribute setting.  The newer LLVM introduced a new MemoryEffects attribute set for onlyRead, onlyWrite ..., separated from the function attribute set: no_unwind, converge and etc.  The memory effect attributes cannot be directly passed to the getOrInsertFunction.  Hence, we need to separate out the MemoryEffects attributes to set them independently.  The new memory side effects also use mixed Function::Attributes (onlyRead, onlyWrite) and MemoryEffects::MemoryLocation (onlyAccessesArgMem, onlyAccessesInaccessibleMem), so we introduce a new enum instead for IGC.